### PR TITLE
[BUGFIX] Do not render menus, if settings are empty

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,12 +10,31 @@ declare(strict_types=1);
 
         $menuIndex = 100;
         foreach ($menuConfiguration->getActiveMenus() as $menu => $configuration) {
-            $typoScriptSetup .= sprintf(
-<<<EOTS
-page.20.dataProcessing.{$menuIndex} = %s
-page.20.dataProcessing.{$menuIndex} {
-    as = menu%s
-    levels = %s
+            $typoScriptSetup .= sprintf('
+page.20.dataProcessing.%1$d = %2$s
+page.20.dataProcessing.%1$d {
+    as = menu%3$s
+    levels = %4$s
+    if.isTrue.cObject = CONTENT
+    if.isTrue.cObject {
+        table = pages
+        select {
+            pidInList.data = leveluid:0
+            recursive = 10
+            join = tx_editablemenus_menu_pages_mm m ON m.uid_foreign=pages.uid
+            where {
+                data = leveluid:0
+                wrap = {#m.field_name} = "%5$s_menu" AND {#m.uid_local}=|
+            }
+            orderBy = m.sorting asc
+        }
+        renderObj = TEXT
+        renderObj {
+            field = uid
+            wrap = |,
+        }
+        stdWrap.substring = 0,-1
+    }
     special = list
     special.value.cObject = CONTENT
     special.value.cObject {
@@ -26,7 +45,7 @@ page.20.dataProcessing.{$menuIndex} {
             join = tx_editablemenus_menu_pages_mm m ON m.uid_foreign=pages.uid
             where {
                 data = leveluid:0
-                wrap = {#m.field_name} = "%s_menu" AND {#m.uid_local}=|
+                wrap = {#m.field_name} = "%5$s_menu" AND {#m.uid_local}=|
             }
             orderBy = m.sorting asc
         }
@@ -38,8 +57,7 @@ page.20.dataProcessing.{$menuIndex} {
         stdWrap.substring = 0,-1
     }
 }
-
-EOTS, \TYPO3\CMS\Frontend\DataProcessing\MenuProcessor::class, \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($menu), $configuration['levels'] ?? 1, $menu
+', $menuIndex, \TYPO3\CMS\Frontend\DataProcessing\MenuProcessor::class, \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($menu), $configuration['levels'] ?? 1, $menu
         );
 
             ++$menuIndex;


### PR DESCRIPTION
Check if there are pages selected in the respective menu field before running the data actual processing to avoid menu pages determined from empty settings.